### PR TITLE
Fix bfs-preview when bfs-max-size is nil due to large-file-warning-th…

### DIFF
--- a/bfs.el
+++ b/bfs.el
@@ -1465,7 +1465,7 @@ When FIRST-TIME is non-nil, set the window layout."
            (bfs-preview-buffer child
                                (format "File ignored due to its extension: %s"
                                        (file-name-extension child))))
-          ((and (file-exists-p child)
+          ((and (file-exists-p child) bfs-max-size
                 (> (file-attribute-size (file-attributes (file-truename child)))
                    bfs-max-size))
            (bfs-preview-buffer child


### PR DESCRIPTION
Hi Tony, 

THX for bfs, seems to be cool little app. While checking it out it bailed on me. I found the problem to be 'bfs-max-size' which had nil value. In my Emacs it is nil since I have set 'large-file-warning-threshold' to nil. That is common thing to do when people don't want Emacs to prompt them when opening large files. You can check this SX aswer:

https://unix.stackexchange.com/questions/108259/how-do-i-stop-emacs-from-asking-me-if-i-want-to-load-a-large-file

The patch just adds a check to see if 'bf-max-size is not nil, so it is very trivial, actually.



